### PR TITLE
Allow custom PWRTelegram API URL

### DIFF
--- a/example.js
+++ b/example.js
@@ -16,12 +16,13 @@ if (!username) {
     console.error("Error: Telegram username missing");
     process.exit(1);
 }
+const url = process.env.PWRTELEGRAM_URL;
 const tgresolve = require(".");
-const tgresolver = new tgresolve.Tgresolve(token);
+const tgresolver = new tgresolve.Tgresolve(token, { url });
 
 
 // using the bare function
-tgresolve(token, username, function(error, user) {
+tgresolve(token, username, { url }, function(error, user) {
     if (error) {
         console.error("Error (bare): %s\n%j", error, error);
         return;

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ var tgresolve = module.exports = function (token, chatId, options, callback) {
 }
 
 
-tgresolve.Tgresolve = function Tgresolve(token, options={}) {
+tgresolve.Tgresolve = function Tgresolve(token, options) {
     this.token = token;
     this.options = Object.assign({
         url,

--- a/index.js
+++ b/index.js
@@ -15,15 +15,22 @@ var request = require('request');
 
 // API Constants
 
-var url = 'https://api.pwrtelegram.xyz/bot'
+var url = 'https://api.pwrtelegram.xyz'
 var method = 'getChat'
 var type = 'chat_id'
 
 // Resolver Function
 
-var tgresolve = module.exports = function (token, chatId, callback) {
+var tgresolve = module.exports = function (token, chatId, options, callback) {
+    if (!callback) {
+        callback = options;
+        options = {};
+    }
+
+    options.url = options.url || url;
+
     request({
-        uri: url + token + '/' + method + '?' + type + '=' + chatId,
+        uri: options.url + '/bot' + token + '/' + method + '?' + type + '=' + chatId,
         json: true
     }, function (error, response, body) {
         if (error) {
@@ -43,11 +50,14 @@ var tgresolve = module.exports = function (token, chatId, callback) {
 }
 
 
-tgresolve.Tgresolve = function Tgresolve(token) {
+tgresolve.Tgresolve = function Tgresolve(token, options={}) {
     this.token = token;
+    this.options = Object.assign({
+        url,
+    }, options);
 };
 
 
 tgresolve.Tgresolve.prototype.tgresolve = function (chatId, callback) {
-    return tgresolve(this.token, chatId, callback);
+    return tgresolve(this.token, chatId, this.options, callback);
 };


### PR DESCRIPTION
Feature:

    We can specify a custom URL for different PWRTelegram
    API servers. The function signatures have been changed
    to allow an OPTIONAL options object. For example,

        // using 'bare' function
        tgresolve(token, username, options, callback);

        // using 'client'
        const resolver = new tgresolver.Tgresolve(token, options);
        resolver.tgresolve(username, callback);

    The 'options' parameter is an object with the following possible
    parameters:

        * 'url': URL to custom PWRTelegram API server

Implementation:

    * completely backwards-compatible